### PR TITLE
ci: use workflow_dispatch for publishing for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn dlx commit-watch
 
   build-and-test:
-    name: Build
+    name: Build & Test
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,46 +30,30 @@ jobs:
           CI_BASE_BRANCH: origin/${{ github.base_ref }}
         run: yarn dlx commit-watch
 
-  build:
+  build-and-test:
     name: Build
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v3
+
       - name: Prepare Environment
         uses: ./.github/actions/prepare-env
+
+      - uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: ${{ github.job }}-${{ github.ref_name }}-
+
       - name: Build packages
         run: yarn prepack
 
-  tests:
-    name: Tests
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare Environment
-        uses: ./.github/actions/prepare-env
-      - name: Run Tests
+      - name: Tests
         run: yarn test
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare Environment
-        uses: ./.github/actions/prepare-env
-      - name: Run ESLint
+      - name: Lint
         run: yarn lint
 
-  types:
-    name: Typecheck
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare Environment
-        uses: ./.github/actions/prepare-env
-      - name: Check Types
+      - name: Typecheck
         run: yarn typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,7 @@
 name: Deploy & Publish
 
 on:
-  workflow_run:
-    workflows: ['Continuous Integration']
-    paths:
-      - '**/packages/**/*'
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish Packages
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          GH_TOKEN: ${{ secrets.PR_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn monodeploy --log-level 0 --config-file monodeploy.config.js --push
 
   deploy-storybook:

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "g:test": "vitest",
     "g:coverage": "vitest --coverage",
     "commit-msg": "commitlint --edit",
-    "prepack": "turbo run build",
-    "test": "turbo run test",
-    "lint": "turbo run lint",
-    "typecheck": "turbo run typecheck"
+    "prepack": "turbo run build --cache-dir=\".turbo\"",
+    "test": "turbo run test --cache-dir=\".turbo\"",
+    "lint": "turbo run lint --cache-dir=\".turbo\"",
+    "typecheck": "turbo run typecheck --cache-dir=\".turbo\""
   }
 }


### PR DESCRIPTION
Fixes issue where publish workflow would run twice on each merge; probably a better idea in the short term anyway so that we're not publishing constantly 😅 

Not going to lie: feels a bit weird putting all the build and test tasks into a single job instead of running them in parallel, but with the caching set up it _did_ just complete the entire run in 20 seconds. Maybe we'll have to revisit this set up later but it might make sense for now.