### PR TITLE
ci: update actions and remove dep for storybook deploy

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
 
     - name: Restore Yarn Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .yarn/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip ci]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/actions/prepare-env
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: .turbo
           key: ${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare Environment
         uses: ./.github/actions/prepare-env
       - name: Build packages
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-release-check]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/prepare-env
@@ -51,7 +51,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy-storybook.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [pre-release-check]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +59,7 @@ jobs:
       - uses: ./.github/actions/prepare-env
 
       - name: Cache Storybook Assets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.out
           key: storybook-assets-${{ hashFiles('**/package.json', '**/yarn.lock') }}-${{ hashFiles('**/.storybook/**/*')}}


### PR DESCRIPTION
I don't see why we have a dependency on pre-release-check for storybook deploys. We can probably just do this separately from the publish action if storybook infra changes and/or story files change.